### PR TITLE
Secret key must be unique and secret for every installation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Run autotests
       env:
         PARROT_DB_HOST: postgres
-        SECRET_KEY: secret
+        PARROT_SECRET_KEY: secret
       run: |
         poetry run pytest --cov=./ --cov-report=xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Run autotests
       env:
         PARROT_DB_HOST: postgres
+        SECRET_KEY: secret
       run: |
         poetry run pytest --cov=./ --cov-report=xml
 

--- a/parrot/settings.py
+++ b/parrot/settings.py
@@ -5,7 +5,7 @@ env = environ.Env()
 
 BASE_DIR = Path(__file__).parent.parent
 
-SECRET_KEY = '^c!x7!qejlut8=d3=mls9c%u-+(8t#&cfap5#=w%10t@&*b4=6'
+SECRET_KEY = env('SECRET_KEY')
 
 DEBUG = env.bool('DEBUG', False)
 

--- a/parrot/settings.py
+++ b/parrot/settings.py
@@ -5,7 +5,7 @@ env = environ.Env()
 
 BASE_DIR = Path(__file__).parent.parent
 
-SECRET_KEY = env('SECRET_KEY')
+SECRET_KEY = env('PARROT_SECRET_KEY')
 
 DEBUG = env.bool('DEBUG', False)
 


### PR DESCRIPTION
Current implementation uses same open `SECRET_KEY` for all installations. This creates a severe vulnerability.

According to the documentation, changing the secret key will invalidate:

- All sessions if you are using any other session backend than django.contrib.sessions.backends.cache, or are using the default get_session_auth_hash().
- All messages if you are using CookieStorage or FallbackStorage.
- All PasswordResetView tokens.
- Any usage of cryptographic signing, unless a different key is provided.

